### PR TITLE
CI: Upload only whitepaper PDF & distributions to Zenodo; set publication metadata

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -53,6 +53,19 @@ jobs:
           python -m build --sdist --wheel
           ls -lah dist
 
+      - name: Build whitepaper PDF (dry-run)
+        run: |
+          set -euo pipefail
+          if [ -f docs/whitepaper/phylogenic_whitepaper.tex ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended || true
+            pdflatex -interaction=nonstopmode -halt-on-error -output-directory docs/whitepaper docs/whitepaper/phylogenic_whitepaper.tex || true
+            if [ -f docs/whitepaper/phylogenic_whitepaper.pdf ]; then
+              mkdir -p dist
+              mv docs/whitepaper/phylogenic_whitepaper.pdf dist/
+            fi
+          fi
+
       - name: Collect zenodo metadata payload
         run: |
           set -euo pipefail
@@ -76,7 +89,8 @@ if os.path.exists(zen_file):
     meta.update(extra)
 payload={'metadata':{
     'title': f"{meta.get('name','') or os.environ.get('RELEASE_NAME')} {os.environ.get('RELEASE_TAG')}",
-    'upload_type':'software',
+    'upload_type':'publication',
+    'publication_type':'report',
     'description': os.environ.get('RELEASE_BODY','').strip() or f'Release {os.environ.get("RELEASE_TAG")}',
     'creators':[],
     'version': meta.get('version',''),
@@ -107,6 +121,8 @@ PY
           jq . .zenodo/payload.json || true
           echo "Files to upload:"
           ls -lah dist || true
+          echo "Whitepaper PDFs:"
+          ls -lah docs/whitepaper/*.pdf || true
           if [ "$DRY_RUN" = "true" ]; then
             echo "DRY RUN enabled: No remote uploads will be performed.";
             exit 0

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -114,6 +114,21 @@ with open('.zenodo/payload.json','w') as f:
 print('Wrote .zenodo/payload.json')
 PY
 
+      - name: Validate zenodo payload and PDFs
+        run: |
+          set -euo pipefail
+          echo "Validating .zenodo/payload.json ..."
+          jq -e '.metadata.upload_type == "publication"' .zenodo/payload.json >/dev/null || (echo "ERROR: payload.metadata.upload_type is not 'publication'" && exit 1)
+          if jq -e '.metadata.publication_type' .zenodo/payload.json >/dev/null 2>&1; then
+            jq -e '.metadata.publication_type == "report"' .zenodo/payload.json >/dev/null || (echo "ERROR: payload.metadata.publication_type is not 'report'" && exit 1)
+          fi
+          if ls dist/*.pdf 1> /dev/null 2>&1 || ls docs/whitepaper/*.pdf 1> /dev/null 2>&1; then
+            echo "Found PDF artifact for upload."
+          else
+            echo "ERROR: No PDF artifact found in dist/ or docs/whitepaper/. Aborting dry-run to avoid empty publication."
+            exit 1
+          fi
+
       - name: Show dry-run summary
         run: |
           echo "Release tag: $RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,24 @@ jobs:
           python -m build --sdist --wheel
           ls -lah dist
 
+      - name: Build whitepaper PDF
+        run: |
+          set -euo pipefail
+          # Attempt to compile the LaTeX whitepaper into a PDF. This is non-fatal
+          # for the release (we don't want to block releases if building the PDF
+          # fails); successful builds are moved into `dist/` for release and Zenodo upload.
+          if [ -f docs/whitepaper/phylogenic_whitepaper.tex ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended || true
+            pdflatex -interaction=nonstopmode -halt-on-error -output-directory docs/whitepaper docs/whitepaper/phylogenic_whitepaper.tex || true
+            if [ -f docs/whitepaper/phylogenic_whitepaper.pdf ]; then
+              mkdir -p dist
+              mv docs/whitepaper/phylogenic_whitepaper.pdf dist/
+            fi
+          else
+            echo "No LaTeX source found at docs/whitepaper/phylogenic_whitepaper.tex; skipping PDF build"
+          fi
+
       - name: Upload to PyPI (if PYPI_API_TOKEN provided)
         if: ${{ secrets.PYPI_API_TOKEN != '' }}
         env:
@@ -96,7 +114,8 @@ if os.path.exists(zenodo_file):
 payload = {
   'metadata': {
     'title': f"{meta.get('name','') or os.environ.get('RELEASE_NAME')} {os.environ.get('RELEASE_TAG')}",
-    'upload_type': 'software',
+    'upload_type': 'publication',
+    'publication_type': 'report',
     'description': os.environ.get('RELEASE_BODY','').strip() or f'Release {os.environ.get("RELEASE_TAG")}',
     'creators': [],
     'version': meta.get('version',''),
@@ -160,10 +179,22 @@ PY
           echo "Zenodo deposition id: $depo_id"
 
           for f in dist/*; do
-            echo "Uploading $f to Zenodo deposition $depo_id..."
-            curl -s -X PUT "$ZENODO_URL/api/deposit/depositions/$depo_id/files?name=$(basename "$f")" \
-              -H "Authorization: Bearer $ZENODO_TOKEN" \
-              --data-binary @"$f"
+            if [ -f "$f" ]; then
+              echo "Uploading $f to Zenodo deposition $depo_id..."
+              curl -s -X PUT "$ZENODO_URL/api/deposit/depositions/$depo_id/files?name=$(basename "$f")" \
+                -H "Authorization: Bearer $ZENODO_TOKEN" \
+                --data-binary @"$f"
+            fi
+          done
+
+          # Also upload whitepaper PDFs if present (docs/whitepaper/)
+          for wp in docs/whitepaper/*.pdf; do
+            if [ -f "$wp" ]; then
+              echo "Uploading $wp to Zenodo deposition $depo_id..."
+              curl -s -X PUT "$ZENODO_URL/api/deposit/depositions/$depo_id/files?name=$(basename "$wp")" \
+                -H "Authorization: Bearer $ZENODO_TOKEN" \
+                --data-binary @"$wp"
+            fi
           done
 
           # Publish deposition

--- a/zenodo-metadata.json
+++ b/zenodo-metadata.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "title": "Phylogenic Whitepaper",
+    "upload_type": "publication",
+    "publication_type": "report",
+    "description": "Phylogenic whitepaper and supplemental materials.",
+    "creators": [
+      { "name": "Jimmy De Jesus" }
+    ],
+    "keywords": ["whitepaper", "phylogenic", "report"]
+  }
+}


### PR DESCRIPTION
Summary:
- Build docs/whitepaper/phylogenic_whitepaper.tex into dist/ (if present).
- Limit Zenodo uploads to dist/* and docs/whitepaper/*.pdf to avoid publishing the full repo.
- Set Zenodo metadata to upload_type: publication and publication_type: report (via zenodo-metadata.json and workflow payload).

Testing:
- Dry-run workflow will include a whitepaper PDF listing and create .zenodo/payload.json with publication metadata.
- Added validation step to the dry-run workflow: it now asserts payload.metadata.upload_type=="publication" and (if present) publication_type=="report", and requires at least one PDF artifact in dist/ or docs/whitepaper/.

Notes:
- If the repository is currently set to auto-archive via the GitHub ↔ Zenodo integration, consider disabling that integration to avoid Zenodo creating a full-repo record. This PR provides CI changes to publish only the whitepaper PDF via the release workflow.

Please review and merge when ready.